### PR TITLE
FB8-264: rocksdb.type_* fail in 8.0.23 because of cardinality

### DIFF
--- a/sql/dd_table_share.cc
+++ b/sql/dd_table_share.cc
@@ -323,6 +323,16 @@ static bool prepare_share(THD *thd, TABLE_SHARE *share,
       share->primary_key = MAX_KEY;
     }
 
+restart:
+    /*
+      The next call is here for MyRocks:  Now, we have filled in field and key
+      definitions, give the storage engine a chance to adjust its properties.
+      MyRocks may (and typically does) adjust HA_PRIMARY_KEY_IN_READ_INDEX
+      flag in this call.
+    */
+    if (handler_file->init_with_fields()) return true;
+    ha_option = handler_file->ha_table_flags();
+
     dd::Table::Index_collection::const_iterator idx_it(
         table_def->indexes().begin());
 
@@ -372,6 +382,13 @@ static bool prepare_share(THD *thd, TABLE_SHARE *share,
         */
         if (primary_key < MAX_KEY && share->keys_in_use.is_set(primary_key)) {
           share->primary_key = primary_key;
+          /*
+            OK, we decided to use it as primary key, but that may have impact on
+            HA_PRIMARY_KEY_IN_READ_INDEX flag, which is set by MyRocks basing on
+            the information about PK. Restart the iteration, but with PK already
+            set.
+          */
+          goto restart;
         }
       }
 
@@ -491,14 +508,6 @@ static bool prepare_share(THD *thd, TABLE_SHARE *share,
 
       ++idx_it;
     }
-
-    /*
-      The next call is here for MyRocks:  Now, we have filled in field and key
-      definitions, give the storage engine a chance to adjust its properties.
-      MyRocks may (and typically does) adjust HA_PRIMARY_KEY_IN_READ_INDEX
-      flag in this call.
-    */
-    if (handler_file->init_with_fields()) return true;
 
     if (primary_key < MAX_KEY &&
         (handler_file->ha_table_flags() & HA_PRIMARY_KEY_IN_READ_INDEX)) {

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2031,6 +2031,15 @@ static int open_binary_frm(THD *thd, TABLE_SHARE *share,
       share->primary_key = MAX_KEY;
     }
 
+restart:
+    /*
+      The next call is here for MyRocks:  Now, we have filled in field and key
+      definitions, give the storage engine a chance to adjust its properties.
+      MyRocks may (and typically does) adjust HA_PRIMARY_KEY_IN_READ_INDEX
+      flag in this call.
+    */
+    if (handler_file->init_with_fields()) goto err;
+
     longlong ha_option = handler_file->ha_table_flags();
     keyinfo = share->key_info;
     key_part = keyinfo->key_part;
@@ -2087,6 +2096,13 @@ static int open_binary_frm(THD *thd, TABLE_SHARE *share,
         */
         if (primary_key < MAX_KEY && share->keys_in_use.is_set(primary_key)) {
           share->primary_key = primary_key;
+          /*
+            OK, we decided to use it as primary key, but that may have impact on
+            HA_PRIMARY_KEY_IN_READ_INDEX flag, which is set by MyRocks basing on
+            the information about PK. Restart the iteration, but with PK already
+            set.
+          */
+          goto restart;
         }
       }
 
@@ -2183,14 +2199,6 @@ static int open_binary_frm(THD *thd, TABLE_SHARE *share,
         share->max_unique_length =
             std::max(share->max_unique_length, keyinfo->key_length);
     }
-
-    /*
-      The next call is here for MyRocks:  Now, we have filled in field and key
-      definitions, give the storage engine a chance to adjust its properties.
-      MyRocks may (and typically does) adjust HA_PRIMARY_KEY_IN_READ_INDEX
-      flag in this call.
-    */
-    if (handler_file->init_with_fields()) goto err;
 
     if (primary_key < MAX_KEY &&
         (handler_file->ha_table_flags() & HA_PRIMARY_KEY_IN_READ_INDEX)) {


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-264

Cause:
8.0.23 changed the logic in
dd_table_share.cc::prepare_share()
table.cc::open_binary_frm()
In particular add_pk_parts_to_sk() call is made only if handler's table
flag HA_PRIMARY_KEY_IN_READ_INDEX is set.
For RocksDB the flag is by default not set, and is in init_with_fields()
if the table contains primary key.

Solution:
ha_rocksdb::init_with_fields() is sensitive only to Primary Key, move
the call just after we set PK in share.
If during the iteration some unique key is chosen to be PK call
init_with_fields() again and restart the iteration with already chosen
PK.