### PR TITLE
FB8-265: main.innodb_pk_extension_on fail in 8.0.23 after porting from 8.0.20

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_cf_per_partition.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_cf_per_partition.result
@@ -363,9 +363,64 @@ Table	Op	Msg_type	Msg_text
 test.t2	analyze	status	OK
 EXPLAIN SELECT  * FROM t2 WHERE col3 = 0x4 AND col2 = 0x34567;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t2	custom_p2	ref	col3	col3	258	const	1	50.00	Using index condition; Using where
+1	SIMPLE	t2	custom_p2	ref	col3	col3	258	const	1	50.00	Using index condition
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t2`.`col1` AS `col1`,`test`.`t2`.`col2` AS `col2`,`test`.`t2`.`col3` AS `col3`,`test`.`t2`.`col4` AS `col4`,`test`.`t2`.`col5` AS `col5` from `test`.`t2` where ((`test`.`t2`.`col2` = 0x034567) and (`test`.`t2`.`col3` = 0x04))
+DROP TABLE t2;
+CREATE TABLE `t2` (
+`col1` bigint NOT NULL,
+`col2` varbinary(64) NOT NULL,
+`col3` varbinary(256) NOT NULL,
+`col4` bigint NOT NULL,
+`col5` mediumblob NOT NULL,
+`col6` bigint NOT NULL,
+PRIMARY KEY (`col1`,`col2`,`col3`) COMMENT 'custom_p0_cfname=test_cf0;custom_p1_cfname=test_cf1',
+KEY (`col2`, `col4`) COMMENT 'custom_p5_cfname=test_cf5'
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+PARTITION BY LIST COLUMNS (`col2`) (
+PARTITION custom_p0 VALUES IN (0x12345),
+PARTITION custom_p1 VALUES IN (0x23456),
+PARTITION custom_p2 VALUES IN (0x34567),
+PARTITION custom_p3 VALUES IN (0x45678),
+PARTITION custom_p4 VALUES IN (0x56789),
+PARTITION custom_p5 VALUES IN (0x6789A),
+PARTITION custom_p6 VALUES IN (0x789AB),
+PARTITION custom_p7 VALUES IN (0x89ABC)
+);
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf0';
+cf_name
+test_cf0
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf1';
+cf_name
+test_cf1
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf5';
+cf_name
+test_cf5
+INSERT INTO t2 VALUES (100, 0x12345, 0x1, 1, 0x2, 1);
+INSERT INTO t2 VALUES (200, 0x12345, 0x1, 1, 0x2, 2);
+INSERT INTO t2 VALUES (300, 0x12345, 0x1, 1, 0x2, 3);
+INSERT INTO t2 VALUES (100, 0x23456, 0x2, 1, 0x3, 4);
+INSERT INTO t2 VALUES (100, 0x34567, 0x4, 1, 0x5, 5);
+INSERT INTO t2 VALUES (400, 0x89ABC, 0x4, 1, 0x5, 6);
+INSERT INTO t2 VALUES (500, 0x6789A, 0x5, 1, 0x7, 7);
+EXPLAIN SELECT  * FROM t2 WHERE col2 = 0x6789A AND col4 = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	custom_p5	ref	col2	col2	74	const,const	1	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`col1` AS `col1`,`test`.`t2`.`col2` AS `col2`,`test`.`t2`.`col3` AS `col3`,`test`.`t2`.`col4` AS `col4`,`test`.`t2`.`col5` AS `col5`,`test`.`t2`.`col6` AS `col6` from `test`.`t2` where ((`test`.`t2`.`col4` = 1) and (`test`.`t2`.`col2` = 0x06789a))
+ALTER TABLE t2 DROP KEY `col2`;
+ALTER TABLE t2 ADD KEY (`col3`, `col4`) COMMENT 'custom_p5_cfname=another_cf_for_p5';
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='another_cf_for_p5';
+cf_name
+another_cf_for_p5
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+EXPLAIN SELECT  * FROM t2 WHERE col3 = 0x4 AND col5 = 3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	custom_p0,custom_p1,custom_p2,custom_p3,custom_p4,custom_p5,custom_p6,custom_p7	ref	col3	col3	258	const	8	10.00	Using index condition; Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`col1` AS `col1`,`test`.`t2`.`col2` AS `col2`,`test`.`t2`.`col3` AS `col3`,`test`.`t2`.`col4` AS `col4`,`test`.`t2`.`col5` AS `col5`,`test`.`t2`.`col6` AS `col6` from `test`.`t2` where ((`test`.`t2`.`col3` = 0x04) and (`test`.`t2`.`col5` = 3))
 DROP TABLE t2;
 CREATE TABLE `t2` (
 `col1` bigint NOT NULL,

--- a/mysql-test/suite/rocksdb/t/rocksdb_cf_per_partition.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_cf_per_partition.test
@@ -421,7 +421,71 @@ SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='
 
 # Verify that correct partition and key are used when searching.
 ANALYZE TABLE t2;
+
+# col2 is part of PK, so it was added to SK
+# That's why we do not expect here.
 EXPLAIN SELECT  * FROM t2 WHERE col3 = 0x4 AND col2 = 0x34567;
+
+DROP TABLE t2;
+
+#
+# The same as above, but the key after ALTER TABLE (col3) does not include PK part
+#
+CREATE TABLE `t2` (
+  `col1` bigint NOT NULL,
+  `col2` varbinary(64) NOT NULL,
+  `col3` varbinary(256) NOT NULL,
+  `col4` bigint NOT NULL,
+  `col5` mediumblob NOT NULL,
+  `col6` bigint NOT NULL,
+  PRIMARY KEY (`col1`,`col2`,`col3`) COMMENT 'custom_p0_cfname=test_cf0;custom_p1_cfname=test_cf1',
+  KEY (`col2`, `col4`) COMMENT 'custom_p5_cfname=test_cf5'
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+  PARTITION BY LIST COLUMNS (`col2`) (
+    PARTITION custom_p0 VALUES IN (0x12345),
+    PARTITION custom_p1 VALUES IN (0x23456),
+    PARTITION custom_p2 VALUES IN (0x34567),
+    PARTITION custom_p3 VALUES IN (0x45678),
+    PARTITION custom_p4 VALUES IN (0x56789),
+    PARTITION custom_p5 VALUES IN (0x6789A),
+    PARTITION custom_p6 VALUES IN (0x789AB),
+    PARTITION custom_p7 VALUES IN (0x89ABC)
+);
+
+# Verify that CF-s were created for PK.
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf0';
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf1';
+
+# Verify that CF-s were created for SK.
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='test_cf5';
+
+# Insert some random data.
+INSERT INTO t2 VALUES (100, 0x12345, 0x1, 1, 0x2, 1);
+INSERT INTO t2 VALUES (200, 0x12345, 0x1, 1, 0x2, 2);
+INSERT INTO t2 VALUES (300, 0x12345, 0x1, 1, 0x2, 3);
+INSERT INTO t2 VALUES (100, 0x23456, 0x2, 1, 0x3, 4);
+INSERT INTO t2 VALUES (100, 0x34567, 0x4, 1, 0x5, 5);
+INSERT INTO t2 VALUES (400, 0x89ABC, 0x4, 1, 0x5, 6);
+INSERT INTO t2 VALUES (500, 0x6789A, 0x5, 1, 0x7, 7);
+
+# Basic verification that correct partition and key are used when searching.
+EXPLAIN SELECT  * FROM t2 WHERE col2 = 0x6789A AND col4 = 1;
+
+# Remove the key.
+ALTER TABLE t2 DROP KEY `col2`;
+
+# Add a new key and expect new CF to be created as well.
+ALTER TABLE t2 ADD KEY (`col3`, `col4`) COMMENT 'custom_p5_cfname=another_cf_for_p5';
+
+# Verify that CF-s were created for SK.
+SELECT DISTINCT(cf_name) FROM information_schema.rocksdb_cfstats WHERE cf_name='another_cf_for_p5';
+
+# Verify that correct partition and key are used when searching.
+ANALYZE TABLE t2;
+
+# col5 is not part of PK (it is not part of any key), so it was not added to SK
+# That's why we expect 'Using where' here.
+EXPLAIN SELECT  * FROM t2 WHERE col3 = 0x4 AND col5 = 3;
 
 DROP TABLE t2;
 


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-265

Post push fix.

After fixing PB8-265 (commit 865b375a), rocksdb_cf_per_partition MTR
test started to fail in the following way:
-1	SIMPLE	t2	custom_p2	ref	col3	col3	258	const	1	50.00	Using index condition; Using where
+1	SIMPLE	t2	custom_p2	ref	col3	col3	258	const	1	50.00	Using index condition

Cause:
Fixing PB8-265 causes proper recognition that PK parts are added to SK.
That causes 'Using where' not to be used as all condition fields are
part of SK (col2 is not in an explicit way, but it is part of PK which was
added to SK)

Solution:
1. Existing test case re-recorded
2. Added test case which uses field not being part of a key, which
causes 'Using where' strategy appearing in 'Extra' column.