### PR TITLE
FB8-276 - Fix test tmp_table_bytes_written

### DIFF
--- a/mysql-test/suite/innodb/r/tmp_table_bytes_written.result
+++ b/mysql-test/suite/innodb/r/tmp_table_bytes_written.result
@@ -1,5 +1,5 @@
-create table t1 (i int, c char(255));
-create table t2 (i int, c varchar(255));
+create table t1 (i int, c char(255), index(i, c));
+create table t2 (i int, c varchar(255), index(i, c));
 insert into t1 values (0, lpad('a', 250, 'b'));
 insert into t1 select i+1,c from t1;
 insert into t1 select i+2,c from t1;
@@ -15,7 +15,7 @@ insert into t1 select i+1024,c from t1;
 insert into t1 select i+2048,c from t1;
 insert into t1 select i+4096,c from t1;
 insert into t2 select * from t1;
-set session tmp_table_size=16384;
+set session tmp_table_size=1024*1024;
 set session max_heap_table_size=16384;
 create temporary table tm(i int, c char(255)) engine=innodb;
 include/assert.inc [The above statements should have increased Tmp_table_bytes_written]
@@ -37,7 +37,7 @@ i	c	count(*)
 include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
 select i, c, count(*) from t2 group by i, c having count(*) > 1;
 i	c	count(*)
-include/assert.inc [The above statements should not have notincreased Tmp_table_bytes_written]
+include/assert.inc [The above statements should not have not increased Tmp_table_bytes_written]
 drop temporary table tm;
 create temporary table tm(i int, c char(255)) engine=innodb;
 insert into tm select * from t1;

--- a/mysql-test/suite/innodb/t/tmp_table_bytes_written.test
+++ b/mysql-test/suite/innodb/t/tmp_table_bytes_written.test
@@ -2,8 +2,10 @@
 
 --let $prevSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
 
-create table t1 (i int, c char(255));
-create table t2 (i int, c varchar(255));
+# Add an index so the folloging `select ... group by` commands don't generate a temp tables
+# https://dev.mysql.com/doc/refman/8.0/en/internal-temporary-tables.html
+create table t1 (i int, c char(255), index(i, c));
+create table t2 (i int, c varchar(255), index(i, c));
 
 insert into t1 values (0, lpad('a', 250, 'b'));
 insert into t1 select i+1,c from t1;
@@ -96,7 +98,7 @@ select i, c, count(*) from t1 group by i, c having count(*) > 1;
 select i, c, count(*) from t2 group by i, c having count(*) > 1;
 
 --let $nextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
---let $assert_text= The above statements should not have notincreased Tmp_table_bytes_written
+--let $assert_text= The above statements should not have not increased Tmp_table_bytes_written
 --let $assert_cond= $nextSize = $prevSize
 --source include/assert.inc
 --let $prevSize = $nextSize


### PR DESCRIPTION
***

Problem:

The `select ... group by ...` orders generate a tmp table due to the
`group by` order does not match the table order.

https://dev.mysql.com/doc/refman/8.0/en/group-by-optimization.html

Solution:

Create an index in the table so the rows are ordered by the same
criteria as the `group by` clause. This way no tmp table is generated.
